### PR TITLE
Fixed Enums parsing for crashes on Empty values or duplicate values.

### DIFF
--- a/ReClass.NET/DataExchange/ReClass/ReClassNetFile.Read.cs
+++ b/ReClass.NET/DataExchange/ReClass/ReClassNetFile.Read.cs
@@ -80,16 +80,29 @@ namespace ReClassNET.DataExchange.ReClass
 						var itemName = itemElement.Attribute(XmlNameAttribute)?.Value ?? string.Empty;
 						var itemValue = (long?)itemElement.Attribute(XmlValueAttribute) ?? 0L;
 
-						values.Add(itemName, itemValue);
+						
+						if (!values.ContainsKey(itemName))
+						{
+							values.Add(itemName, itemValue);
+						}
+						else
+						{
+							
+							values[itemName] = itemValue; 
+						}
 					}
 
-					var @enum = new EnumDescription
+					// Check if there are any values before adding the enum to prevent crashing
+					if (values.Count > 0)
 					{
-						Name = name
-					};
-					@enum.SetData(useFlagsMode, size, values);
+						var @enum = new EnumDescription
+						{
+							Name = name
+						};
+						@enum.SetData(useFlagsMode, size, values);
 
-					project.AddEnum(@enum);
+						project.AddEnum(@enum);
+					}
 				}
 			}
 


### PR DESCRIPTION
the original code attempted to add every parsed enum to the project without checking if it contained any values. It also did have handling for the possibility of duplicate enum item names within the same enum which could also cause crashes.